### PR TITLE
Ignore fields that are embedded

### DIFF
--- a/nested_set.go
+++ b/nested_set.go
@@ -69,6 +69,9 @@ func parseNode(db *gorm.DB, source interface{}) (tx *gorm.DB, item nestedItem, e
 		v := sourceValue.Field(i)
 
 		schemaField := scm.LookUpField(t.Name)
+		if schemaField == nil {
+		    continue;
+		}
 		dbName := schemaField.DBName
 
 		switch t.Tag.Get("nestedset") {


### PR DESCRIPTION
I have a struct like this. The `LocationForm` type contains all fields editable by the user. 

```go
type Location struct {
      ID            int64         `json:"id" gorm:"PRIMARY_KEY;AUTO_INCREMENT" nestedset:"id"`
      ParentID      sql.NullInt64 `json:"parent_id" nestedset:"parent_id"`
      Rgt           int           `json:"rgt" nestedset:"rgt"`
      Lft           int           `json:"lft" nestedset:"lft"`
      Depth         int           `json:"depth" nestedset:"depth"`
      ChildrenCount int           `json:"children_count" nestedset:"children_count"`
  
      CreatedAt time.Time     `json:"created_at"`
      UpdatedAt time.Time     `json:"updated_at"`
      DeletedAt NullDeletedAt `json:"deleted_at" gorm:"index" swaggertype:"primitive,string"`
  
      State map[string]int `json:"state,omitempty" gorm:"-"`
  
      LocationForm `gorm:"embedded"` <-- CRASH
  }
  
  ```
  ```
  2022/11/11 16:16:20 [Recovery] 2022/11/11 - 16:16:20 panic recovered:
runtime error: invalid memory address or nil pointer dereference
.gvm/gos/go1.18.2/src/runtime/panic.go:220 (0x453675)
	panicmem: panic(memoryError)
.gvm/gos/go1.18.2/src/runtime/signal_unix.go:818 (0x453645)
	sigpanic: panicmem()
go/pkg/mod/github.com/longbridgeapp/nested-set@v1.5.1/nested_set.go:74 (0xd39b23)
	parseNode: dbName := schemaField.DBName
go/pkg/mod/github.com/longbridgeapp/nested-set@v1.5.1/nested_set.go:286 (0xd3a4ef)
	Rebuild: tx, target, err := parseNode(db, source)
```
  
  Unfortunately this results in a `nil pointer dereference` crash. Since it crashes on the embedded type I just added a condition to skip it. 
  
  There are probably better, more advanced ways of fixing this. But it was good enough for me :)